### PR TITLE
Gmp optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pip install -e .
 ```
 *Note that the `-e` flag will instruct pip to install the package as "editable". That is, when changes are made to any part of the package during development, those changes will immediately be available system-wide on the activated python environment.*
 
+For best performance, [install gmpy2](https://gmpy2.readthedocs.io/en/latest/intro.html#installation).
+
 All requirements for this package should be added to `setup.py`.
 
 ## Public and Private Keys

--- a/damgard_jurik/crypto.py
+++ b/damgard_jurik/crypto.py
@@ -11,11 +11,9 @@ from math import factorial
 from secrets import randbelow
 from typing import Any, List, Tuple
 
-from gmpy2 import mpz
-
 from damgard_jurik.prime_gen import gen_safe_prime_pair
 from damgard_jurik.shamir import share_secret
-from damgard_jurik.utils import int_to_mpz, crm, inv_mod, pow_mod
+from damgard_jurik.utils import int_to_mpz, crm, inv_mod, pow_mod, mpzCast
 
 
 class EncryptedNumber:
@@ -169,7 +167,7 @@ class PublicKey:
         :return: An EncryptedNumber containing the encryption of `m`.
         """
         # Choose random r in Z_n^*
-        r = mpz(randbelow(self.n - 1)) + 1
+        r = mpzCast(randbelow(self.n - 1)) + 1
         c = pow(self.n + 1, m, self.n_s_1) * pow(r, self.n_s, self.n_s_1) % self.n_s_1
 
         return EncryptedNumber(value=c, public_key=self)
@@ -271,17 +269,17 @@ def damgard_jurik_reduce(a: int, s: int, n: int) -> int:
     @lru_cache(int(s))
     @int_to_mpz
     def fact(k: int) -> int:
-        return mpz(factorial(k))
+        return mpzCast(factorial(k))
 
-    i = mpz(0)
+    i = mpzCast(0)
     for j in range(1, s + 1):
-        j = mpz(j)
+        j = mpzCast(j)
 
         t_1 = L(a % n_pow(j + 1))
         t_2 = i
 
         for k in range(2, j + 1):
-            k = mpz(k)
+            k = mpzCast(k)
 
             i = i - 1
             t_2 = t_2 * i % n_pow(j)
@@ -337,7 +335,7 @@ class PrivateKeyRing:
             return l
 
         # Decrypt
-        c_prime = mpz(1)
+        c_prime = mpzCast(1)
         for c_i, i in zip(c_list, self.i_list):
             c_prime = (c_prime * pow_mod(c_i, (2 * lam(i)), self.public_key.n_s_1)) % self.public_key.n_s_1
 

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -64,7 +64,7 @@ def gen_safe_prime(n_bits: int) -> int:
                 if is_prime(p):
                     return p
             else:
-                if is_prime(p):
+                if is_prime(p, 15):
                     return p
 
 

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -9,10 +9,25 @@ Contains methods for generating prime numbers.
 from secrets import randbits
 from typing import Tuple
 
-from gmpy2 import bit_set, is_prime, next_prime
+try:
+    try:
+        from gmpy2 import bit_set, is_prime, next_prime
+    except ImportError:
+        from gmpy import bit_set, is_prime, next_prime
+except ImportError:
+    GMP_AVAILABLE = False
+else:
+    GMP_AVAILABLE = True
 
+if (not GMP_AVAILABLE):
+    try:
+        from Cryptodome.Util.number import isPrime as is_prime
+        from Cryptodome.Util.number import getPrime as crypto_prime
+    except ImportError:
+        from Crypto.Util.number import isPrime as is_prime
+        from Crypto.Util.number import getPrime as crypto_prime
 
-def gen_prime(n_bits: int) -> int:
+def gmp_prime(n_bits: int) -> int:
     """Returns a prime number with `n_bits` bits.
 
     :param n_bits: The number of bits the prime number should contain.
@@ -23,6 +38,12 @@ def gen_prime(n_bits: int) -> int:
     p = next_prime(base)
 
     return p
+
+if (GMP_AVAILABLE):
+    gen_prime = gmp_prime
+else:
+    def gen_prime (n_bits: int) -> int:
+        return crypto_prime(n_bits)
 
 
 def gen_safe_prime(n_bits: int) -> int:

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -9,20 +9,11 @@ Contains methods for generating prime numbers.
 from secrets import randbits
 from typing import Tuple
 
-from gmpy2 import bit_set, is_prime, next_prime
+from Crypto.Util.number import getPrime, isPrime
 
 
 def gen_prime(n_bits: int) -> int:
-    """Returns a prime number with `n_bits` bits.
-
-    :param n_bits: The number of bits the prime number should contain.
-    :return: A prime number with `n_bits` bits.
-    """
-    base = randbits(n_bits)
-    base = bit_set(base, n_bits - 1)
-    p = next_prime(base)
-
-    return p
+    return getPrime(n_bits)
 
 
 def gen_safe_prime(n_bits: int) -> int:
@@ -34,12 +25,12 @@ def gen_safe_prime(n_bits: int) -> int:
     :return: A safe prime with `n_bits` bits.
     """
     while True:
-        q = gen_prime(n_bits - 1)
+        q = getPrime(n_bits - 1)
 
-        if is_prime(q):
+        if isPrime(q):
             p = 2 * q + 1
 
-            if is_prime(p):
+            if isPrime(p):
                 return p
 
 

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -9,14 +9,20 @@ Contains methods for generating prime numbers.
 from secrets import randbits
 from typing import Tuple
 
-try:
-    from Cryptodome.Util.number import getPrime, isPrime
-except ImportError:
-    from Crypto.Util.number import getPrime, isPrime
+from gmpy2 import bit_set, is_prime, next_prime
 
 
 def gen_prime(n_bits: int) -> int:
-    return getPrime(n_bits)
+    """Returns a prime number with `n_bits` bits.
+
+    :param n_bits: The number of bits the prime number should contain.
+    :return: A prime number with `n_bits` bits.
+    """
+    base = randbits(n_bits)
+    base = bit_set(base, n_bits - 1)
+    p = next_prime(base)
+
+    return p
 
 
 def gen_safe_prime(n_bits: int) -> int:
@@ -28,12 +34,12 @@ def gen_safe_prime(n_bits: int) -> int:
     :return: A safe prime with `n_bits` bits.
     """
     while True:
-        q = getPrime(n_bits - 1)
+        q = gen_prime(n_bits - 1)
 
-        if isPrime(q):
+        if is_prime(q):
             p = 2 * q + 1
 
-            if isPrime(p):
+            if is_prime(p):
                 return p
 
 

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -9,7 +9,10 @@ Contains methods for generating prime numbers.
 from secrets import randbits
 from typing import Tuple
 
-from Crypto.Util.number import getPrime, isPrime
+try:
+    from Crypto.Util.number import getPrime, isPrime
+except ImportError:
+    from Cryptodome.Util.number import getPrime, isPrime
 
 
 def gen_prime(n_bits: int) -> int:

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -60,8 +60,12 @@ def gen_safe_prime(n_bits: int) -> int:
         if is_prime(q):
             p = 2 * q + 1
 
-            if is_prime(p):
-                return p
+            if (GMP_AVAILABLE):
+                if is_prime(p):
+                    return p
+            else:
+                if is_prime(p):
+                    return p
 
 
 def gen_safe_prime_pair(n_bits: int) -> Tuple[int, int]:

--- a/damgard_jurik/prime_gen.py
+++ b/damgard_jurik/prime_gen.py
@@ -10,9 +10,9 @@ from secrets import randbits
 from typing import Tuple
 
 try:
-    from Crypto.Util.number import getPrime, isPrime
-except ImportError:
     from Cryptodome.Util.number import getPrime, isPrime
+except ImportError:
+    from Crypto.Util.number import getPrime, isPrime
 
 
 def gen_prime(n_bits: int) -> int:

--- a/damgard_jurik/shamir.py
+++ b/damgard_jurik/shamir.py
@@ -9,9 +9,7 @@ Contains an implementation of Shamir's secret sharing.
 from secrets import randbelow
 from typing import List, Tuple
 
-from gmpy2 import mpz
-
-from damgard_jurik.utils import int_to_mpz, inv_mod
+from damgard_jurik.utils import int_to_mpz, inv_mod, mpzCast
 
 
 class Polynomial:
@@ -24,7 +22,7 @@ class Polynomial:
         :param coeffs: The coefficients of x^0, x^1, x^2, ...
         :param modulus: The modulus of the field the polynomial is in.
         """
-        self.coeffs = [mpz(c_i) for c_i in coeffs]
+        self.coeffs = [mpzCast(c_i) for c_i in coeffs]
         self.modulus = modulus
 
     @int_to_mpz
@@ -34,10 +32,10 @@ class Polynomial:
         :param x: The input to the polynomial.
         :return: The integer f(x) where f is this polynomial.
         """
-        f_x = mpz(0)
+        f_x = mpzCast(0)
 
         for i, c_i in enumerate(self.coeffs):
-            f_x = (f_x + c_i * pow(x, mpz(i), self.modulus) % self.modulus) % self.modulus
+            f_x = (f_x + c_i * pow(x, mpzCast(i), self.modulus) % self.modulus) % self.modulus
 
         return f_x
 
@@ -70,7 +68,7 @@ def share_secret(secret: int,
     f = Polynomial(coeffs, modulus)
 
     # Use the polynomial to share the secret
-    X = [mpz(x) for x in range(1, n_shares + 1)]
+    X = [mpzCast(x) for x in range(1, n_shares + 1)]
     shares = [(x, f(x)) for x in X]
 
     return shares
@@ -88,12 +86,12 @@ def reconstruct(shares: List[Tuple[int, int]],
     :return: The secret.
     """
     # Convert to mpz
-    shares = [(mpz(x), mpz(f_x)) for x, f_x in shares]
+    shares = [(mpzCast(x), mpzCast(f_x)) for x, f_x in shares]
 
     # Reconstruct secret
-    secret = mpz(0)
+    secret = mpzCast(0)
     for i, (x_i, f_x_i) in enumerate(shares):
-        product = mpz(1)
+        product = mpzCast(1)
 
         for j, (x_j, _) in enumerate(shares):
             if i != j:

--- a/damgard_jurik/utils.py
+++ b/damgard_jurik/utils.py
@@ -10,8 +10,22 @@ from functools import wraps
 from math import gcd
 from typing import Callable, List, Tuple
 
-from gmpy2 import mpz
 
+try:
+    try:
+        from gmpy2 import mpz
+    except ImportError:
+        from gmpy import mpz
+except ImportError:
+    GMP_AVAILABLE = False
+else:
+    GMP_AVAILABLE = True
+
+def mpzCast(num: int) -> int:
+    if (GMP_AVAILABLE):
+        return mpz(num)
+    else:
+        return num
 
 def int_to_mpz(func: Callable) -> Callable:
     """A decorator which converts all int arguments to mpz.
@@ -19,12 +33,14 @@ def int_to_mpz(func: Callable) -> Callable:
     :param func: The function to decorate.
     :return: The function `func` but with all int arguments converted to mpz.
     """
-    @wraps(func)
-    def func_wrapper(*args, **kwargs):
-        return func(*[mpz(arg) if isinstance(arg, int) else arg for arg in args],
-                    **{key: mpz(value) if isinstance(value, int) else value for key, value in kwargs.items()})
-    return func_wrapper
-
+    if (GMP_AVAILABLE):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            return func(*[mpz(arg) if isinstance(arg, int) else arg for arg in args],
+                        **{key: mpz(value) if isinstance(value, int) else value for key, value in kwargs.items()})
+        return func_wrapper
+    else:
+        return func
 
 def prod(nums: List[int]) -> int:
     """Returns the product of the numbers in the list.
@@ -32,7 +48,7 @@ def prod(nums: List[int]) -> int:
     :param nums: A list of integers.
     :return: The product of the numbers in `nums`.
     """
-    product = mpz(1)
+    product = mpzCast(1)
 
     for num in nums:
         product *= num
@@ -66,7 +82,7 @@ def extended_euclidean(a: int, b: int) -> Tuple[int, int]:
     :param b: The integer b in the above equation.
     :return: A tuple of integers x and y such that ax + by = gcd(a, b).
     """
-    x0, x1, y0, y1 = mpz(0), mpz(1), mpz(1), mpz(0)
+    x0, x1, y0, y1 = mpzCast(0), mpzCast(1), mpzCast(1), mpzCast(0)
 
     while a != 0:
         q, b, a = b // a, a, b % a
@@ -104,8 +120,8 @@ def crm(a_list: List[int], n_list: List[int]) -> int:
     :param n_list: A list of integers b_i in the above equation.
     :return: The unique integer x such that x = a_i (mod n_i) for all i.
     """
-    a_list = [mpz(a_i) for a_i in a_list]
-    n_list = [mpz(n_i) for n_i in n_list]
+    a_list = [mpzCast(a_i) for a_i in a_list]
+    n_list = [mpzCast(n_i) for n_i in n_list]
 
     N = prod(n_list)
     y_list = [N // n_i for n_i in n_list]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setuptools.setup(
     url='https://github.com/cryptovoting/damgard-jurik',
     packages=setuptools.find_packages(),
     install_requires=[
-        'gmpy2'
+        'gmpy2',
+        'pycryptodome'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     url='https://github.com/cryptovoting/damgard-jurik',
     packages=setuptools.find_packages(),
     install_requires=[
-        'pycryptodome'
+        'pycryptodomex'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
     url='https://github.com/cryptovoting/damgard-jurik',
     packages=setuptools.find_packages(),
     install_requires=[
-        'gmpy2',
         'pycryptodome'
     ],
     classifiers=[


### PR DESCRIPTION
Fixes #4 

damgård-jurik will take advantage of either `gmpy2` or `gmpy` but doesn't require either. PyCryptodome is used for random prime generation.

## Explanation

### [`@int_to_mpz`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/damgard_jurik/utils.py#L30-L43)

`@int_to_mpz` existed before this pull request. It takes a function and its inputs as inputs. It goes through each input and casts to `mpz` if appropriate. With this update, if `not GMP_AVAILABLE`, then the given function is returned with out any modifications.

### [`mpzCast()`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/damgard_jurik/utils.py#L24-L28)

Prior to this update, explicit casts to `mpz()` existed throughout the source code. With the exception of inside `@int_to_mpz`, all `mpz()`s were replaced with the the function `mpzCast()` that only casts to `mpz` if possible.

I chose a function rather than a type alias, so that if a user inputs a custom integral type, the output will be in that type unless `mpz` is available, which takes priority.

### [`gen_prime()`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/damgard_jurik/prime_gen.py#L18-L19) and [`gen_safe_prime()`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/damgard_jurik/prime_gen.py#L22-L37)

[outdated:]In `gen_saf_prime()` calls to `gen_prime()` are replaced with `Crypto...getPrime()` and calls to `Gmpy2...isPrime()` is replaced with `Crypto...isPrime()`. `gen_prime()` has been kept for backwards compatibility. It is now merely a wrapper for `Crypto...getPrime()`.

### PyCrypto requirements

There are two similar libraries, PyCrypto and PyCryptodome. PyCryptodome is overall better than PyCrypto, however both of them suit our purposes, and [`damgard-jurik/prime_gen.py`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/damgard_jurik/prime_gen.py#L12-L15) will work with either of them. PyCrypto's package name is `pycrypto` and module name is `Crypto`. PyCryptodome has two variants, with package names `pycryptodome` and `pycryptodomex`, and the only difference is the module names. `pycryptodome`'s module name is `Crypto`, and `pycryptodomex`'s name is `Cryptodome`. Since `pycryptodome` and `pycrypto` have the same name, they will break if installed in the same environment at the same time. With [`setup.py`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/setup.py#L27) only one package name can be specified. Since some users may either already have `pycrypto` or `pycryptodome` installed, `pycryptodomex` is the only package that is guaranteed to not break anything. If `pycryptodomex` is uninstalled after damgard-jurik is installed, then damgard-jurik will keep working as long as either `pycryptodome` or `pycrypto` is installed.

## Performance

[outdated:]As of the opening of this pull request, `test.py` runs an order of magnitude slower than in the master branch whether or not `gmpy2` library is available. Debugging has shown that the library correctly detects `gmpy2` and uses it if possible, but the slowing still exists. I have two hypotheses:

- Key generation runs slower because `Crypto.getPrime()` doesn't use `mpz`. Cryptodome has an undocumented prime generator that does use mpz for internal use only.
- [`mpzCast()`](https://github.com/NCGThompson/damgard-jurik/blob/b82f0e94971bdcd669d8b7afb1176df43cd207aa/damgard_jurik/utils.py#L24-L28) calls take longer than a simple cast, and the sheer number of them slow computation down.

Neither sound likely, but I don't have any other ideas. Until I figure out how to speed up computation, I will keep this pull request a draft.